### PR TITLE
removal of listeners before closing results in disconnect state not being set

### DIFF
--- a/lib/network/transport/udp.js
+++ b/lib/network/transport/udp.js
@@ -18,13 +18,13 @@ var UDPTransport = module.exports = StateEventEmitter.extend({
       self.setState('connected', self.iam);
     });
     this._socket.once('close', function() {
-      this.setState('disconnected');
+      self.setState('disconnected');
+      self._socket.removeAllListeners();
     });
     this._socket.bind(this._port);
   },
 
   disconnect: function() {
-    this._socket.removeAllListeners();
     this._socket.close();
   },
 


### PR DESCRIPTION
Hi,

I noticed that the disconnect state was not being propagated after closing the udp connection. I believe it is because the listeners are removed before the socket is closed.  This pull request has my fix, but you might want to double check whether my moving the "removeAllListeners" is the right thing to do.

Cheers,
Gary
